### PR TITLE
Add wait to binding

### DIFF
--- a/demo/cmd/demo-wasm/hello.go
+++ b/demo/cmd/demo-wasm/hello.go
@@ -65,9 +65,3 @@ func (h *Hello) OnMenuClick(s, e js.Value) {
 			}},
 	)
 }
-
-type Nav app.ZeroCompo
-
-func (n *Nav) Render() string {
-	return `<p>nav</p>`
-}

--- a/demo/makefile
+++ b/demo/makefile
@@ -3,7 +3,7 @@ build:
 
 deploy: build
 	@cp -r web cmd/demo-server/web
-	gcloud app deploy cmd/demo-server 
+	gcloud app deploy cmd/demo-server --project=app-demo-232021
 	@rm -r cmd/demo-server/web
 
 clean:

--- a/pkg/app/app.go
+++ b/pkg/app/app.go
@@ -17,7 +17,7 @@ var (
 
 	ui         = make(chan func(), 256)
 	components = make(compoBuilder)
-	msgs       = &messenger{}
+	msgs       = &messenger{callOnUI: UI}
 )
 
 // Import imports the given components into the app.

--- a/pkg/app/app_wasm.go
+++ b/pkg/app/app_wasm.go
@@ -16,13 +16,6 @@ var (
 )
 
 func init() {
-	page = &dom{
-		compoBuilder:        components,
-		callOnUI:            UI,
-		trackCursorPosition: trackCursorPosition,
-		contextMenu:         &contextMenu{},
-	}
-
 	log.DefaultColor = ""
 	log.InfoColor = ""
 	log.ErrorColor = ""
@@ -33,6 +26,13 @@ func init() {
 
 func run() {
 	go func() {
+		page = &dom{
+			compoBuilder:        components,
+			callOnUI:            UI,
+			msgs:                msgs,
+			trackCursorPosition: trackCursorPosition,
+			contextMenu:         &contextMenu{},
+		}
 		defer page.clean()
 
 		overrideAnchorClick := js.FuncOf(overrideAnchorClick)

--- a/pkg/app/contextmenu_wasm.go
+++ b/pkg/app/contextmenu_wasm.go
@@ -16,7 +16,7 @@ type contextMenu struct {
 }
 
 func (m *contextMenu) OnMount() {
-	Bind("__app.NewContextMenu", m).Do(m.new)
+	Bind("__app.NewContextMenu", m).DoOnUI(m.new)
 }
 
 // Render returns the markup that describes the context menu.

--- a/pkg/app/converter_wasm.go
+++ b/pkg/app/converter_wasm.go
@@ -49,3 +49,7 @@ func rawHTML(s string) template.HTML {
 func timeFormat(t time.Time, layout string) string {
 	return t.Format(layout)
 }
+
+func emitter(msg string) template.JS {
+	return template.JS("emit:" + msg)
+}

--- a/pkg/app/converter_wasm_test.go
+++ b/pkg/app/converter_wasm_test.go
@@ -52,3 +52,8 @@ func TestTimeFormat(t *testing.T) {
 	s := timeFormat(time.Date(1986, 2, 14, 0, 0, 0, 0, time.UTC), "2006")
 	assert.Equal(t, "1986", s)
 }
+
+func TestEmitter(t *testing.T) {
+	s := emitter("app.test")
+	assert.Equal(t, "//go:emit:app.test", s)
+}

--- a/pkg/app/dom_wasm.go
+++ b/pkg/app/dom_wasm.go
@@ -328,10 +328,7 @@ func (d *dom) renderTagAttrs(ctx renderContext, n *node, hasAttr bool) {
 		}
 
 		for _, transform := range d.attrTransforms {
-			fmt.Println("----")
-			fmt.Println("before transform", k, v)
 			k, v = transform(k, v)
-			fmt.Println("after transform", k, v)
 		}
 
 		attrs[k] = v

--- a/pkg/app/dom_wasm.go
+++ b/pkg/app/dom_wasm.go
@@ -15,6 +15,7 @@ import (
 
 type dom struct {
 	compoBuilder        compoBuilder
+	msgs                *messenger
 	callOnUI            func(func())
 	trackCursorPosition func(js.Value)
 	contextMenu         Compo
@@ -34,6 +35,7 @@ func (d *dom) init() {
 		"json":  jsonFormat,
 		"raw":   rawHTML,
 		"time":  timeFormat,
+		"emit":  emitter,
 	}
 	d.attrTransforms = []attrTransform{eventTransform}
 }
@@ -326,7 +328,10 @@ func (d *dom) renderTagAttrs(ctx renderContext, n *node, hasAttr bool) {
 		}
 
 		for _, transform := range d.attrTransforms {
+			fmt.Println("----")
+			fmt.Println("before transform", k, v)
 			k, v = transform(k, v)
+			fmt.Println("after transform", k, v)
 		}
 
 		attrs[k] = v
@@ -371,7 +376,7 @@ func (d *dom) setEventHandler(ctx renderContext, n *node, k, v string) {
 		n.eventCloses = make(map[string]func())
 	}
 
-	v = strings.TrimPrefix(v, "//go: ")
+	v = strings.TrimPrefix(v, "//go:")
 	v = strings.ReplaceAll(v, " ", "")
 	n.eventCloses[k] = n.addEventListener(ctx, k, v)
 }

--- a/pkg/app/msg.go
+++ b/pkg/app/msg.go
@@ -135,6 +135,7 @@ type do struct {
 type messenger struct {
 	mutex    sync.RWMutex
 	bindings map[string][]*Binding
+	callOnUI func(func())
 }
 
 func (m *messenger) emit(msg string, args ...interface{}) {
@@ -154,7 +155,10 @@ func (m *messenger) bind(msg string, c Compo) (*Binding, func()) {
 		m.bindings = make(map[string][]*Binding)
 	}
 
-	b := &Binding{msg: msg}
+	b := &Binding{
+		msg:      msg,
+		callOnUI: m.callOnUI,
+	}
 	m.bindings[msg] = append(m.bindings[msg], b)
 
 	close := func() {

--- a/pkg/app/msg.go
+++ b/pkg/app/msg.go
@@ -3,6 +3,7 @@ package app
 import (
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/maxence-charriere/app/pkg/log"
 )
@@ -10,34 +11,50 @@ import (
 // Binding represents a series of functions that are executed successively when
 // a message is emitted.
 type Binding struct {
-	msg   string
-	funcs []reflect.Value
+	msg      string
+	actions  []interface{}
+	callOnUI func(func())
 }
 
 // Do adds a function to be executed when a message is emitted.
 //
-// Function first argument must implement the context.Context interface.
-// https://golang.org/pkg/context/#Context
+// Functions arguments are mapped to the emitted arguments or the return values
+// of the previous function added with Do.
 //
-// Other functions arguments are mapped to the emitted arguments or the return
-// values of the previous function added with Do.
+// Functions added with Do are executed on a different goroutine.
 //
-// It panics if f is not a function or if f first argument does not implements
-// context.Context.
+// It panics if f is not a function.
 func (b *Binding) Do(f interface{}) *Binding {
-	v := reflect.ValueOf(f)
-	typ := v.Type()
+	return b.do(f, false)
+}
 
+// DoOnUI is like Do but the added function is executed on the UI goroutine.
+func (b *Binding) DoOnUI(f interface{}) *Binding {
+	return b.do(f, true)
+}
+
+func (b *Binding) do(f interface{}, callOnUI bool) *Binding {
+	v := reflect.ValueOf(f)
 	if v.Kind() != reflect.Func {
 		log.Error("adding function to binding failed").
 			T("reason", "argument passed in not a function").
-			T("argument type", typ).
+			T("argument type", v.Type()).
 			T("message", b.msg).
-			T("index", len(b.funcs)).
+			T("index", len(b.actions)).
 			Panic()
 	}
 
-	b.funcs = append(b.funcs, v)
+	b.actions = append(b.actions, do{
+		function: v,
+		callOnUI: callOnUI},
+	)
+	return b
+}
+
+// Wait adds the given duration before the execution of the next function added
+// with Do.
+func (b *Binding) Wait(d time.Duration) *Binding {
+	b.actions = append(b.actions, d)
 	return b
 }
 
@@ -47,40 +64,72 @@ func (b *Binding) exec(args ...interface{}) {
 		argsv = append(argsv, reflect.ValueOf(arg))
 	}
 
-	for doIdx, f := range b.funcs {
-		ftype := f.Type()
+	for idx, a := range b.actions {
+		switch action := a.(type) {
+		case time.Duration:
+			time.Sleep(action)
 
-		i := 0
-		for i < ftype.NumIn() && i < len(argsv) {
-			if !argsv[i].Type().AssignableTo(ftype.In(i)) {
-				log.Error("executing binding function failed").
-					T("reason", "non assignable arg").
-					T("message", b.msg).
-					T("function index", doIdx).
-					T("function type", ftype).
-					T("arg index", i).
-					T("expected type", ftype.In(i)).
-					T("arg type", argsv[i].Type())
+		case do:
+			ok := false
+			if argsv, ok = b.execDo(idx, action, argsv); !ok {
 				return
 			}
-			i++
 		}
-
-		for i < ftype.NumIn() {
-			log.Warn("binding function argument missing").
-				T("message", b.msg).
-				T("function index", doIdx).
-				T("function type", ftype).
-				T("arg index", i).
-				T("arg type", ftype.In(i)).
-				T("pkg fix", "assigned to zero value")
-			argsv = append(argsv, reflect.Zero(ftype.In(i)))
-			i++
-		}
-
-		argsv = argsv[:i]
-		argsv = f.Call(argsv)
 	}
+}
+
+func (b *Binding) execDo(idx int, do do, args []reflect.Value) ([]reflect.Value, bool) {
+	fnval := do.function
+	fntype := fnval.Type()
+
+	i := 0
+	for i < fntype.NumIn() && i < len(args) {
+		if !args[i].Type().AssignableTo(fntype.In(i)) {
+			log.Error("executing binding function failed").
+				T("reason", "non assignable arg").
+				T("message", b.msg).
+				T("function index", idx).
+				T("function type", fntype).
+				T("arg index", i).
+				T("expected type", fntype.In(i)).
+				T("arg type", args[i].Type())
+			return nil, false
+		}
+		i++
+	}
+
+	for i < fntype.NumIn() {
+		log.Warn("binding function argument missing").
+			T("message", b.msg).
+			T("function index", idx).
+			T("function type", fntype).
+			T("arg index", i).
+			T("arg type", fntype.In(i)).
+			T("pkg fix", "assigned to zero value")
+		args = append(args, reflect.Zero(fntype.In(i)))
+		i++
+	}
+
+	args = args[:i]
+
+	if do.callOnUI {
+		retchan := make(chan []reflect.Value, 1)
+		defer close(retchan)
+
+		b.callOnUI(func() {
+			retchan <- fnval.Call(args)
+		})
+		args = <-retchan
+
+	} else {
+		args = fnval.Call(args)
+	}
+	return args, true
+}
+
+type do struct {
+	function reflect.Value
+	callOnUI bool
 }
 
 type messenger struct {

--- a/pkg/app/transform_wasm.go
+++ b/pkg/app/transform_wasm.go
@@ -10,10 +10,8 @@ func eventTransform(k, v string) (string, string) {
 	if !strings.HasPrefix(k, "on") {
 		return k, v
 	}
-
 	if strings.HasPrefix(v, "js:") {
 		return k, strings.TrimPrefix(v, "js:")
 	}
-
-	return k, "//go: " + v
+	return k, "//go:" + v
 }

--- a/pkg/app/transform_wasm_test.go
+++ b/pkg/app/transform_wasm_test.go
@@ -17,5 +17,5 @@ func TestEventTransform(t *testing.T) {
 
 	k, v = eventTransform("onchange", "OnChange")
 	assert.Equal(t, "onchange", k)
-	assert.Equal(t, "//go: OnChange", v)
+	assert.Equal(t, "//go:OnChange", v)
 }


### PR DESCRIPTION
## Summary
- Binding can execute a function on the UI goroutine.
- Binding can wait for a duration before execution the next function.
- Message can be emitted from html events.

```go
func (h *Hello) OnMount() {
	// Binding to the nameChanged msg that wait 1 second and print logs on
	// binding an ui gouroutines.
	app.Bind("nameChanged", h).
		Wait(time.Second).
		Do(func() {
			log.Debug("log from binding goroutine")
		}).
		DoOnUI(func() {
			log.Debug("log from UI goroutine")
		}).
		Do(func() {
			log.Debug("another log from binding goroutine")
		})

	// Binding that is called from an html event and modify the Name field.
	app.Bind("nameChanged", h).
		DoOnUI(func(s, e js.Value) {
			h.Name = s.Get("value").String()
			app.Render(h)
		})
}

func (h *Hello) Render() string {
	// Input emit a "nameChanged" message when the onchange event occurs.
	return `
<div>
	<!-- ... -->
	<input 
		value="{{.Name}}" 
		placeholder="What is your name?" 
		onchange={{emit nameChanged}} 
		autofocus>
	<!-- ... -->
</div>
	`
}
```

## Fixes
- Removed some inaccurate documentation.