### PR TITLE
Use UI rather than Node in Range methods

### DIFF
--- a/pkg/app/http.go
+++ b/pkg/app/http.go
@@ -209,7 +209,7 @@ func (h *Handler) initPage() {
 						Type("text/css").
 						Rel("stylesheet").
 						Href("/app.css"),
-					Range(h.Styles).Slice(func(i int) Node {
+					Range(h.Styles).Slice(func(i int) UI {
 						return Link().
 							Type("text/css").
 							Rel("stylesheet").
@@ -217,11 +217,11 @@ func (h *Handler) initPage() {
 					}),
 					Script().Src("/wasm_exec.js"),
 					Script().Src("/app.js"),
-					Range(h.Scripts).Slice(func(i int) Node {
+					Range(h.Scripts).Slice(func(i int) UI {
 						return Script().
 							Src(h.Scripts[i])
 					}),
-					Range(h.RawHeaders).Slice(func(i int) Node {
+					Range(h.RawHeaders).Slice(func(i int) UI {
 						return Raw(h.RawHeaders[i])
 					}),
 				),

--- a/pkg/app/menu.go
+++ b/pkg/app/menu.go
@@ -170,8 +170,8 @@ func (l *contextMenuLayout) Render() UI {
 				Class("app-contextmenu").
 				Body(
 					Range(l.items).
-						Slice(func(i int) Node {
-							return l.items[i]
+						Slice(func(i int) UI {
+							return l.items[i].(UI)
 						}),
 				),
 		)

--- a/pkg/app/node_wasm_test.go
+++ b/pkg/app/node_wasm_test.go
@@ -38,7 +38,7 @@ func TestIndirect(t *testing.T) {
 		{
 			scenario: "indirect range condition node returns a standard nodes",
 			node: Range([]int{1, 2, 3}).
-				Slice(func(i int) Node {
+				Slice(func(i int) UI {
 					return Div()
 				}),
 			expected: []reflect.Type{
@@ -85,7 +85,7 @@ func TestMount(t *testing.T) {
 		{
 			scenario: "mounting range condition node returns an error",
 			node: Range([]int{42}).
-				Slice(func(int) Node {
+				Slice(func(int) UI {
 					return Div()
 				}),
 			err: true,

--- a/pkg/app/range.go
+++ b/pkg/app/range.go
@@ -18,13 +18,13 @@ type RangeLoop interface {
 	// number of elements in the source.
 	//
 	// It panics if the range source is not a slice or an array.
-	Slice(f func(int) Node) RangeLoop
+	Slice(f func(int) UI) RangeLoop
 
 	// Map sets the loop content by repeating the given function for the number
 	// of elements in the source. Elements are ordered by keys.
 	//
 	// It panics if the range source is not a map or if map keys are not strings.
-	Map(f func(string) Node) RangeLoop
+	Map(f func(string) UI) RangeLoop
 }
 
 // Range returns a range loop that iterates within the given source. Source must
@@ -46,7 +46,7 @@ func (c rangeCondition) nodes() []UI {
 	return c.body
 }
 
-func (c rangeCondition) Slice(f func(int) Node) RangeLoop {
+func (c rangeCondition) Slice(f func(int) UI) RangeLoop {
 	v := reflect.ValueOf(c.source)
 	if v.Kind() != reflect.Slice && v.Kind() != reflect.Array {
 		log.Error("range source is not a slice or array").
@@ -61,7 +61,7 @@ func (c rangeCondition) Slice(f func(int) Node) RangeLoop {
 	return c
 }
 
-func (c rangeCondition) Map(f func(string) Node) RangeLoop {
+func (c rangeCondition) Map(f func(string) UI) RangeLoop {
 	v := reflect.ValueOf(c.source)
 	if v.Kind() != reflect.Map {
 		log.Error("range source is not a map").

--- a/pkg/app/range_test.go
+++ b/pkg/app/range_test.go
@@ -15,7 +15,7 @@ func TestRangeConditionSlice(t *testing.T) {
 	}
 
 	rs := Range(s).
-		Slice(func(i int) Node {
+		Slice(func(i int) UI {
 			return Text(s[i])
 		})
 	require.Equal(t, reflect.TypeOf(rs), rs.nodeType())
@@ -26,7 +26,7 @@ func TestRangeConditionSlice(t *testing.T) {
 
 	require.Panics(t, func() {
 		Range(42).
-			Slice(func(int) Node {
+			Slice(func(int) UI {
 				return nil
 			})
 	})
@@ -40,21 +40,21 @@ func TestRangeConditionMap(t *testing.T) {
 	}
 
 	rm := Range(m).
-		Map(func(k string) Node {
+		Map(func(k string) UI {
 			return Text(m[k])
 		})
 	require.Len(t, rm.nodes(), 3)
 
 	require.Panics(t, func() {
 		Range(42).
-			Map(func(string) Node {
+			Map(func(string) UI {
 				return nil
 			})
 	})
 
 	require.Panics(t, func() {
 		Range(map[int]string{42: ""}).
-			Map(func(string) Node {
+			Map(func(string) UI {
 				return nil
 			})
 	})


### PR DESCRIPTION
## Summary
- Use UI rather than Node in `Range.Slice` and `Range.Map`

